### PR TITLE
Core Server Registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,9 @@ project(FMCB)
 
 # Add any (internal) directories containing a CMakeLists.txt that should be built here
 add_subdirectory(core)
-add_subdirectory(shared/memory)
+add_subdirectory(shared)
+
+add_subdirectory(tests)
 
 # Add subsystem directories containing a CMakeLists.txt here
 # This will need to modularized later

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_CXX_FLAGS_DEBUG  "-g")
 set(CMAKE_CXX_FLAGS_RELEASE  "-O3 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO  "-O2 -g -DNDEBUG")
 
+# Is this correct? Either way, it does seem to slow compilation to a slightly annoying degree, is cmake/ninja recompiling files that don't need to be?
+set(CMAKE_EXE_LINKER_FLAGS "-static-libstdc++ -static-libgcc")
+
 project(FMCB)
 
 # Add any (internal) directories containing a CMakeLists.txt that should be built here

--- a/build/build.bat
+++ b/build/build.bat
@@ -3,7 +3,7 @@
 if "%2%" == "core" (
 	set targets=core/all shared/memory/all
 ) else (
-	set targets=
+	set targets=%2%
 )
 
 cd ../bin

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,3 @@
-# Add as a download?
 include_directories(${CMAKE_SOURCE_DIR}/minparse/include)
 
 add_executable(Core Core.cpp)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,3 +1,4 @@
 include_directories(${CMAKE_SOURCE_DIR}/minparse/include)
 
-add_executable(Core Core.cpp)
+# This should probably be improved, the core server could potentially become quite large
+add_executable(Core Core.cpp registration/PipeServer.cpp registration/Register.cpp)

--- a/core/Core.cpp
+++ b/core/Core.cpp
@@ -5,7 +5,6 @@
 #include "registration/Register.h"
 
 #include <iostream>
-#include <vector>
 #include <atomic>
 #include <climits>
 // ? Can we include a slightly less bloated header?
@@ -16,7 +15,7 @@ HANDLE inputThreadHandle; // TODO: maybe put this somewhere else
 std::atomic<bool> shouldExit = false; // TODO: Write a better way of doing this
 
 void cleanupAndExit() {
-	std::cout << "Cleaning up; you should receive one more message before the program exits." << std::endl;
+	std::cout << "Preparing to exit; you should receive a message before the program exits." << std::endl;
 
 	if (inputThreadHandle != NULL) {
 		/*
@@ -65,7 +64,7 @@ int main(int argc, char** argv) {
 
 			This mode will output extensive debugging info related to connections, internal feature processing, etc.
 			*/
-			// Alternatively, test code could be controlled via the preprocessor, and two versions of the core server could be built.
+			// * Alternatively, test code could be controlled via the preprocessor, and two versions of the core server could be built.
 			std::cout << "Core server started in test mode" << std::endl;
 
 			break;

--- a/core/Core.cpp
+++ b/core/Core.cpp
@@ -1,42 +1,15 @@
+#include "Global.h"
+#include "minparse.h"
+
+#include "registration/PipeServer.h"
+#include "registration/Register.h"
+
 #include <iostream>
 #include <vector>
 #include <atomic>
 #include <climits>
 // ? Can we include a slightly less bloated header?
 #include <Windows.h>
-
-#include "minparse.h"
-
-#include "Global.h"
-
-// TODO: replace with variable; pipe count must be <= maxSubsystems
-#define PIPE_COUNT 2
-#define PIPE_BUFFER_SIZE 32
-
-typedef char SessionID[16]; // 16 bytes * 8 bits = 128 bits
-
-struct PipeInst {
-	HANDLE handle = INVALID_HANDLE_VALUE;
-
-	bool waiting = false;
-
-	DWORD bytesRead;
-	char buffer[PIPE_BUFFER_SIZE]; 
-
-	OVERLAPPED overlap;
-};
-
-struct Subsystem {
-	std::string name;
-	SessionID sessionid;
-
-	HANDLE communication;
-};
- 
-PipeInst pipes[PIPE_COUNT]; // ? Should this be configureable?
-
-unsigned char maxSubsystems = 2; // Could probably just use an int, but this adds another level of protection from runoff
-std::vector<Subsystem> clients;
 
 HANDLE inputThreadHandle; // TODO: maybe put this somewhere else
 
@@ -53,11 +26,7 @@ void cleanupAndExit() {
 		CloseHandle(inputThreadHandle);
 	}
 
-	for (int i = 0; i < PIPE_COUNT; i++) {
-		if (pipes[i].handle != INVALID_HANDLE_VALUE) {
-			CloseHandle(pipes[i].handle);
-		}
-	}
+	registration_server::cleanup();
 
 	std::cout << "Cleanup complete, exiting." << std::endl;
 
@@ -116,7 +85,7 @@ int main(int argc, char** argv) {
 					in = 255;
 				}
 
-				maxSubsystems = in;
+				client_register::init(in);
 
 				std::cout << "Max subsystems set to " << in << std::endl;
 			} else {
@@ -152,117 +121,20 @@ int main(int argc, char** argv) {
 		cleanupAndExit();
 	}
 
-	for (int i = 0; i < PIPE_COUNT; i++) {
-		/*
-		! Inherently, this opens up the core server to malicious use,
-		! extreme care must be taken to insure no information is shared that could compromise the host machine.
-
-		This should be shared with subsystem developers in an obvious place, along with a message encouraging them to write secure network code.
-		Even still, the subsystem api should be written in such a way to reduce the risk of an experienced dev opening up their system for exploitation.
-
-		Because of this, a subsystem-side api should be provided, and developers should be highly encouraged to use it, doing otherwise at their own (and any of their users) risk.
-
-		Some/all network data should be encrypted, or an option should at least exist for it (maybe subsystems could opt-in to full or partial encryption depending on their content),
-		as some users may prefer the slight performance boost in exchange for third parties being able to see the volume of dirt transferred between two games (of course network data may not always be so insignificant)
-		*/
-		pipes[i].handle = CreateNamedPipeA(
-			"\\\\.\\pipe\\FMBCRegister",
-			PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
-			PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE,
-			4,
-			1024, // Estimated public key size is 2048 bits, assuming perfect packing (not the case) this can hold 4 public keys at once (a public key being the largest object to be used in a registration handshake)
-			1024,
-			50,
-			NULL
-		);
-
-		if (pipes[i].handle == INVALID_HANDLE_VALUE) {
-			std::cout << "Failed to initialize pipe#" << i << " with error " << GetLastError()
-				<< ". This could be because a previous session was not cleaned up completely, or an application could be attempting to hijack communication." << std::endl;
-
-			cleanupAndExit();
-		}
+	if (!registration_server::init()) {
+		cleanupAndExit();
 	}
 
-	for (int i = 0; i < PIPE_COUNT; i++) {
-		ConnectNamedPipe(pipes[i].handle, &pipes[i].overlap);
-
-		DWORD error = GetLastError();
-
-		if (error != ERROR_IO_PENDING && error != ERROR_PIPE_CONNECTED) {
-			std::cout << "Pipe#" << i << " failed to enable incoming connections with error " << GetLastError() << std::endl;
-
-			cleanupAndExit();
-		}
-	}
-
-	std::cout << "Startup complete, waiting for registration connections" << std::endl;
+	std::cout << "Startup complete" << std::endl;
 
 	while (true) {
-		// TODO: this whole system needs improvement
-		for (int i = 0; i < PIPE_COUNT; i++) {
-			if (shouldExit) {
-				cleanupAndExit();
-			}
-
-			if (pipes[i].waiting) {	
-				if (HasOverlappedIoCompleted(&pipes[i].overlap)) {
-					std::cout << "Pipe#" << i << " finished job, disconnecting subsystem and waiting for a new connection" << std::endl;
-
-					pipes[i].waiting = false;
-
-					DisconnectNamedPipe(pipes[i].handle);
-					// TODO: move reconnect code to a function
-					ConnectNamedPipe(pipes[i].handle, &pipes[i].overlap);
-
-					DWORD error = GetLastError();
-
-					if (error != ERROR_IO_PENDING && error != ERROR_PIPE_CONNECTED) {
-						std::cout << "Pipe#" << i << " failed to re-enable incoming connections with error " << GetLastError() << std::endl;
-
-						// ? Should not exit right away maybe
-						cleanupAndExit();
-					}
-				}
-			} else {
-				ReadFile(
-					pipes[i].handle,
-					&pipes[i].buffer,
-					PIPE_BUFFER_SIZE,
-					&pipes[i].bytesRead,
-					&pipes[i].overlap
-				);
-
-				if (pipes[i].bytesRead != 0) {
-					std::cout << "Connection received on pipe#" << i << std::endl;
-
-					if (clients.size() >= maxSubsystems) {
-						// TODO: implement actual code for this; pipes should notify subsystems attempting to connect that their connection cannot be serviced to prevent them from assuming an instance will soon be available to answer their request.
-						std::cout << "Warning, maximum number of subsystems reached" << std::endl;
-					}
-
-					std::cout << "Name: " << std::string(pipes[i].buffer + 5) << std::endl;
-					std::cout << "PID: " << *((DWORD*) (pipes[i].buffer + 1)) << std::endl;
-
-					// TODO: clean this up
-					int index = clients.size();
-					clients.push_back({"Name", {'a', '3', 'b', '7', '7', 'k'}, NULL}); // TODO: generate a unique SID automatically
-
-					WriteFile(
-						pipes[i].handle,
-						&clients[index].sessionid,
-						16,
-						NULL,
-						&pipes[i].overlap
-					);
-
-					pipes[i].bytesRead = 0;
-					pipes[i].waiting = true;
-				}
-			}
-
-			Sleep(150);
+		if (shouldExit) {
+			cleanupAndExit();
 		}
+
+		registration_server::cycle();
+
+		Sleep(250);
 	}
 
 	cleanupAndExit();

--- a/core/Core.cpp
+++ b/core/Core.cpp
@@ -1,4 +1,6 @@
 #include <iostream>
+// Can we include a slightly less bloated header?
+#include <Windows.h>
 
 #include "minparse.h"
 
@@ -26,6 +28,30 @@ int main(int argc, char** argv) {
 			}
 
 			break;
+
+		default:
+			std::cout << "Invalid parameter \"" << arg.arg[0] << "\"" << std::endl;
+
+			return 0;
 		}
 	}
+
+	std::cout << "Creating subsystem registration pipe" << std::endl;
+
+	HANDLE pipe = CreateNamedPipeA(
+		"\\\\.\\pipe\\FMBCRegister",
+		PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
+		PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE,
+		1,
+		1024,
+		1024,
+		50,
+		NULL
+	);
+
+	std::cout << GetLastError() << std::endl;
+
+	CloseHandle(pipe);
+
+	return 0;
 }

--- a/core/Core.cpp
+++ b/core/Core.cpp
@@ -1,34 +1,53 @@
 #include <iostream>
+#include <vector>
 #include <atomic>
-// Can we include a slightly less bloated header?
+#include <climits>
+// ? Can we include a slightly less bloated header?
 #include <Windows.h>
 
 #include "minparse.h"
 
 #include "Global.h"
 
+// TODO: replace with variable; pipe count must be <= maxSubsystems
 #define PIPE_COUNT 2
-#define PIPE_BUFFER_SIZE 512
+#define PIPE_BUFFER_SIZE 32
+
+typedef char SessionID[16]; // 16 bytes * 8 bits = 128 bits
 
 struct PipeInst {
 	HANDLE handle = INVALID_HANDLE_VALUE;
+
+	bool waiting = false;
+
 	DWORD bytesRead;
-	char buffer[PIPE_BUFFER_SIZE];
+	char buffer[PIPE_BUFFER_SIZE]; 
+
 	OVERLAPPED overlap;
 };
+
+struct Subsystem {
+	std::string name;
+	SessionID sessionid;
+
+	HANDLE communication;
+};
  
-PipeInst pipes[PIPE_COUNT];
+PipeInst pipes[PIPE_COUNT]; // ? Should this be configureable?
 
-HANDLE inputThreadHandle; 
+unsigned char maxSubsystems = 2; // Could probably just use an int, but this adds another level of protection from runoff
+std::vector<Subsystem> clients;
 
-std::atomic<bool> shouldExit = false;
+HANDLE inputThreadHandle; // TODO: maybe put this somewhere else
+
+std::atomic<bool> shouldExit = false; // TODO: Write a better way of doing this
 
 void cleanupAndExit() {
 	std::cout << "Cleaning up; you should receive one more message before the program exits." << std::endl;
 
 	if (inputThreadHandle != NULL) {
 		/*
-		Does this actually exit the thread cleanly?
+		? Does this actually exit the thread cleanly?
 		From the api, it would seem that the thread stack is not unallocated unless it closes itself (though it's probably cleaned up automatically by any remotely recent version of windows).
 		*/
 		CloseHandle(inputThreadHandle);
@@ -58,12 +77,18 @@ DWORD WINAPI inputThread(LPVOID lpThreadParameter) {
 int main(int argc, char** argv) {
 	std::cout << "FMCB core server " << VERSION << std::endl;
 
+	if (CHAR_BIT != 8) {
+		std::cout << "Byte size is not 8, FMCB assumes the size of a byte in order to provide a common ground for subsystems, and to insure the length of certain security keys.\nCritical error detected, shutting down." << std::endl;
+
+		return 0;
+	}
+
 	minparse::init(argc - 1, argv + 1);
 
 	minparse::argument arg = {};
 
 	while (minparse::parse(&arg)) {
-		// Obviously not very good, minparse will need to be farther developed
+		// TODO: Obviously not very good, minparse will need to be farther developed
 		switch (arg.arg[0]) {
 		case 'x':
 			/*
@@ -82,8 +107,20 @@ int main(int argc, char** argv) {
 
 			break;
 		case 's':
-			if (arg.argc == 1) {
-				std::cout << "Max subsystems set to " << arg.argv[0] << std::endl;
+			if (arg.argc == 1) { // TODO: make minparse do checking like this automatically maybe
+				long in = std::strtol(arg.argv[0], nullptr, 10); // TODO: maybe error check a bit more
+				
+				if (in > 255) {
+					std::cout << "argument 's' must be lower than 256, using maximum value instead." << std::endl; // TODO: make minparse do error checking like this automatically maybe
+
+					in = 255;
+				}
+
+				maxSubsystems = in;
+
+				std::cout << "Max subsystems set to " << in << std::endl;
+			} else {
+				std::cout << "argument 's' must be an integer between 0 and 255, ignoring given values." << std::endl;
 			}
 
 			break;
@@ -99,7 +136,7 @@ int main(int argc, char** argv) {
 	Need to use win32 threads as my gcc doesn't like posix, I think because I told it to on installation. I could just reinstall, but where's the fun in that?
 	Besides, we're already going to be writting platform-specific code, using the native functions gives us more control, and should in theory give a tiny performance edge, not that we need it for anything.
 	*/
-	// Is 1024 bytes enough for C++ std I/O? It should run anyway, but forcing memory to be allocated at runtime can't be good for performance.
+	// ? Is 1024 bytes enough for C++ std I/O? It should run anyway, but forcing memory to be allocated at runtime can't be good for performance.
 	inputThreadHandle = CreateThread(
 		NULL,
 		1024,
@@ -162,38 +199,67 @@ int main(int argc, char** argv) {
 	std::cout << "Startup complete, waiting for registration connections" << std::endl;
 
 	while (true) {
+		// TODO: this whole system needs improvement
 		for (int i = 0; i < PIPE_COUNT; i++) {
 			if (shouldExit) {
 				cleanupAndExit();
 			}
 
-			// Readfile may "fail" occasionally at high check rates as it is asynchronous, this should be fixed.
-			if (pipes[i].bytesRead != 0) {
-				std::cout << "Connection received on pipe#" << i << std::endl;
+			if (pipes[i].waiting) {	
+				if (HasOverlappedIoCompleted(&pipes[i].overlap)) {
+					std::cout << "Pipe#" << i << " finished job, disconnecting subsystem and waiting for a new connection" << std::endl;
 
-				std::cout << "Data written: " << +pipes[i].buffer[0] << +pipes[i].buffer[1] << std::endl;
+					pipes[i].waiting = false;
 
-				DisconnectNamedPipe(pipes[i].handle);
+					DisconnectNamedPipe(pipes[i].handle);
+					// TODO: move reconnect code to a function
+					ConnectNamedPipe(pipes[i].handle, &pipes[i].overlap);
 
-				ConnectNamedPipe(pipes[i].handle, &pipes[i].overlap);
+					DWORD error = GetLastError();
 
-				DWORD error = GetLastError();
+					if (error != ERROR_IO_PENDING && error != ERROR_PIPE_CONNECTED) {
+						std::cout << "Pipe#" << i << " failed to re-enable incoming connections with error " << GetLastError() << std::endl;
 
-				if (error != ERROR_IO_PENDING && error != ERROR_PIPE_CONNECTED) {
-					std::cout << "Pipe#" << i << " failed to enable incoming connections with error " << GetLastError() << std::endl;
+						// ? Should not exit right away maybe
+						cleanupAndExit();
+					}
+				}
+			} else {
+				ReadFile(
+					pipes[i].handle,
+					&pipes[i].buffer,
+					PIPE_BUFFER_SIZE,
+					&pipes[i].bytesRead,
+					&pipes[i].overlap
+				);
 
-					// Should not exit right away maybe
-					cleanupAndExit();
+				if (pipes[i].bytesRead != 0) {
+					std::cout << "Connection received on pipe#" << i << std::endl;
+
+					if (clients.size() >= maxSubsystems) {
+						// TODO: implement actual code for this; pipes should notify subsystems attempting to connect that their connection cannot be serviced to prevent them from assuming an instance will soon be available to answer their request.
+						std::cout << "Warning, maximum number of subsystems reached" << std::endl;
+					}
+
+					std::cout << "Name: " << std::string(pipes[i].buffer + 5) << std::endl;
+					std::cout << "PID: " << *((DWORD*) (pipes[i].buffer + 1)) << std::endl;
+
+					// TODO: clean this up
+					int index = clients.size();
+					clients.push_back({"Name", {'a', '3', 'b', '7', '7', 'k'}, NULL}); // TODO: generate a unique SID automatically
+
+					WriteFile(
+						pipes[i].handle,
+						&clients[index].sessionid,
+						16,
+						NULL,
+						&pipes[i].overlap
+					);
+
+					pipes[i].bytesRead = 0;
+					pipes[i].waiting = true;
 				}
 			}
-
-			ReadFile(
-				pipes[i].handle,
-				&pipes[i].buffer,
-				PIPE_BUFFER_SIZE,
-				&pipes[i].bytesRead,
-				&pipes[i].overlap
-			);
 
 			Sleep(150);
 		}

--- a/core/Core.cpp
+++ b/core/Core.cpp
@@ -7,7 +7,43 @@
 
 #include "Global.h"
 
+#define PIPE_COUNT 2
+#define PIPE_BUFFER_SIZE 512
+
+struct PipeInst {
+	HANDLE handle = INVALID_HANDLE_VALUE;
+	DWORD bytesRead;
+	char buffer[PIPE_BUFFER_SIZE];
+	OVERLAPPED overlap;
+};
+ 
+PipeInst pipes[PIPE_COUNT];
+
+HANDLE inputThreadHandle; 
+
 std::atomic<bool> shouldExit = false;
+
+void cleanupAndExit() {
+	std::cout << "Cleaning up; you should receive one more message before the program exits." << std::endl;
+
+	if (inputThreadHandle != NULL) {
+		/*
+		Does this actually exit the thread cleanly?
+		From the api, it would seem that the thread stack is not unallocated unless it closes itself (though it's probably cleaned up automatically by any remotely recent version of windows).
+		*/
+		CloseHandle(inputThreadHandle);
+	}
+
+	for (int i = 0; i < PIPE_COUNT; i++) {
+		if (pipes[i].handle != INVALID_HANDLE_VALUE) {
+			CloseHandle(pipes[i].handle);
+		}
+	}
+
+	std::cout << "Cleanup complete, exiting." << std::endl;
+
+	std::exit(0);
+}
 
 DWORD WINAPI inputThread(LPVOID lpThreadParameter) {
 	int a;
@@ -59,40 +95,12 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	std::cout << "Creating subsystem registration pipe" << std::endl;
-
-	/*
-	! Inherently, this opens up the core server to malicious use,
-	! extreme care must be taken to insure no information is shared that could compromise the host machine.
-
-	This should be shared with subsystem developers in an obvious place, along with a message encouraging them to write secure network code.
-	Even still, the subsystem api should be written in such a way to reduce the risk of an experienced dev opening up their system for exploitation.
-
-	Because of this, a subsystem-side api should be provided, and developers should be highly encouraged to use it, doing otherwise at their own (and any of their users) risk.
-
-	Some/all network data should be encrypted, or an option should at least exist for it (maybe subsystems could opt-in to full or partial encryption depending on their content),
-	as some users may prefer the slight performance boost in exchange for third parties being able to see the volume of dirt transferred between two games (of course network data may not always be so insignificant)
-	*/
-	HANDLE pipe = CreateNamedPipeA(
-		"\\\\.\\pipe\\FMBCRegister",
-		PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
-		PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE,
-		4,
-		1024, // Estimated public key size is 2048 bits, assuming perfect packing (not the case) this can hold 4 public keys at once (a public key being the largest object to be used in a registration handshake)
-		1024,
-		50,
-		NULL
-	);
-
-	std::cout << GetLastError() << std::endl;
-
 	/*
 	Need to use win32 threads as my gcc doesn't like posix, I think because I told it to on installation. I could just reinstall, but where's the fun in that?
 	Besides, we're already going to be writting platform-specific code, using the native functions gives us more control, and should in theory give a tiny performance edge, not that we need it for anything.
 	*/
-	// Should do this after core server has finished starting up
-	// Is 1024 bytes enough for C++ std i/o?
-	CreateThread(
+	// Is 1024 bytes enough for C++ std I/O? It should run anyway, but forcing memory to be allocated at runtime can't be good for performance.
+	inputThreadHandle = CreateThread(
 		NULL,
 		1024,
 		inputThread,
@@ -101,40 +109,95 @@ int main(int argc, char** argv) {
 		NULL
 	);
 
-	OVERLAPPED state = {};
+	if (inputThreadHandle == NULL) {
+		std::cout << "Input thread failed to start with error " << GetLastError() << std::endl;
 
-	ConnectNamedPipe(pipe, &state);
-
-	DWORD bytes = 0;
-	char buffer[2] = {};
-	OVERLAPPED overlapped = {};
-
-	while (true) {
-		// Readfile may "fail" occasionally at high check rates as it is asynchronous"
-		if (bytes != 0) {
-			std::cout << "Connected: " << +buffer[0] << "/" << +buffer[1] << std::endl;
-
-			DisconnectNamedPipe(pipe);
-
-			break;
-		}
-
-		ReadFile(
-			pipe,
-			&buffer,
-			2,
-			&bytes,
-			&overlapped
-		);
-
-		if (shouldExit) {
-			break;
-		}
-
-		Sleep(500);
+		cleanupAndExit();
 	}
 
-	CloseHandle(pipe);
+	for (int i = 0; i < PIPE_COUNT; i++) {
+		/*
+		! Inherently, this opens up the core server to malicious use,
+		! extreme care must be taken to insure no information is shared that could compromise the host machine.
 
-	return 0;
+		This should be shared with subsystem developers in an obvious place, along with a message encouraging them to write secure network code.
+		Even still, the subsystem api should be written in such a way to reduce the risk of an experienced dev opening up their system for exploitation.
+
+		Because of this, a subsystem-side api should be provided, and developers should be highly encouraged to use it, doing otherwise at their own (and any of their users) risk.
+
+		Some/all network data should be encrypted, or an option should at least exist for it (maybe subsystems could opt-in to full or partial encryption depending on their content),
+		as some users may prefer the slight performance boost in exchange for third parties being able to see the volume of dirt transferred between two games (of course network data may not always be so insignificant)
+		*/
+		pipes[i].handle = CreateNamedPipeA(
+			"\\\\.\\pipe\\FMBCRegister",
+			PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+			PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE,
+			4,
+			1024, // Estimated public key size is 2048 bits, assuming perfect packing (not the case) this can hold 4 public keys at once (a public key being the largest object to be used in a registration handshake)
+			1024,
+			50,
+			NULL
+		);
+
+		if (pipes[i].handle == INVALID_HANDLE_VALUE) {
+			std::cout << "Failed to initialize pipe#" << i << " with error " << GetLastError()
+				<< ". This could be because a previous session was not cleaned up completely, or an application could be attempting to hijack communication." << std::endl;
+
+			cleanupAndExit();
+		}
+	}
+
+	for (int i = 0; i < PIPE_COUNT; i++) {
+		ConnectNamedPipe(pipes[i].handle, &pipes[i].overlap);
+
+		DWORD error = GetLastError();
+
+		if (error != ERROR_IO_PENDING && error != ERROR_PIPE_CONNECTED) {
+			std::cout << "Pipe#" << i << " failed to enable incoming connections with error " << GetLastError() << std::endl;
+
+			cleanupAndExit();
+		}
+	}
+
+	std::cout << "Startup complete, waiting for registration connections" << std::endl;
+
+	while (true) {
+		for (int i = 0; i < PIPE_COUNT; i++) {
+			if (shouldExit) {
+				cleanupAndExit();
+			}
+
+			// Readfile may "fail" occasionally at high check rates as it is asynchronous, this should be fixed.
+			if (pipes[i].bytesRead != 0) {
+				std::cout << "Connection received on pipe#" << i << std::endl;
+
+				std::cout << "Data written: " << +pipes[i].buffer[0] << +pipes[i].buffer[1] << std::endl;
+
+				DisconnectNamedPipe(pipes[i].handle);
+
+				ConnectNamedPipe(pipes[i].handle, &pipes[i].overlap);
+
+				DWORD error = GetLastError();
+
+				if (error != ERROR_IO_PENDING && error != ERROR_PIPE_CONNECTED) {
+					std::cout << "Pipe#" << i << " failed to enable incoming connections with error " << GetLastError() << std::endl;
+
+					// Should not exit right away maybe
+					cleanupAndExit();
+				}
+			}
+
+			ReadFile(
+				pipes[i].handle,
+				&pipes[i].buffer,
+				PIPE_BUFFER_SIZE,
+				&pipes[i].bytesRead,
+				&pipes[i].overlap
+			);
+
+			Sleep(150);
+		}
+	}
+
+	cleanupAndExit();
 }

--- a/core/Core.cpp
+++ b/core/Core.cpp
@@ -1,10 +1,23 @@
 #include <iostream>
+#include <atomic>
 // Can we include a slightly less bloated header?
 #include <Windows.h>
 
 #include "minparse.h"
 
 #include "Global.h"
+
+std::atomic<bool> shouldExit = false;
+
+DWORD WINAPI inputThread(LPVOID lpThreadParameter) {
+	int a;
+
+	std::cin >> a;
+
+	shouldExit = true;
+
+	return 0;
+}
 
 int main(int argc, char** argv) {
 	std::cout << "FMCB core server " << VERSION << std::endl;
@@ -16,9 +29,19 @@ int main(int argc, char** argv) {
 	while (minparse::parse(&arg)) {
 		// Obviously not very good, minparse will need to be farther developed
 		switch (arg.arg[0]) {
+		case 'x':
+			/*
+			Used by subsystem developers in order to test their code.
+
+			This mode will output extensive debugging info related to connections, internal feature processing, etc.
+			*/
+			// Alternatively, test code could be controlled via the preprocessor, and two versions of the core server could be built.
+			std::cout << "Core server started in test mode" << std::endl;
+
+			break;
 		case 't':
 			if (arg.argc == 1) {
-				std::cout << "Worker count set to " << arg.argv[0] << std::endl;
+				std::cout << "Processing thread count set to " << arg.argv[0] << std::endl;
 			}
 
 			break;
@@ -38,18 +61,78 @@ int main(int argc, char** argv) {
 
 	std::cout << "Creating subsystem registration pipe" << std::endl;
 
+	/*
+	! Inherently, this opens up the core server to malicious use,
+	! extreme care must be taken to insure no information is shared that could compromise the host machine.
+
+	This should be shared with subsystem developers in an obvious place, along with a message encouraging them to write secure network code.
+	Even still, the subsystem api should be written in such a way to reduce the risk of an experienced dev opening up their system for exploitation.
+
+	Because of this, a subsystem-side api should be provided, and developers should be highly encouraged to use it, doing otherwise at their own (and any of their users) risk.
+
+	Some/all network data should be encrypted, or an option should at least exist for it (maybe subsystems could opt-in to full or partial encryption depending on their content),
+	as some users may prefer the slight performance boost in exchange for third parties being able to see the volume of dirt transferred between two games (of course network data may not always be so insignificant)
+	*/
 	HANDLE pipe = CreateNamedPipeA(
 		"\\\\.\\pipe\\FMBCRegister",
-		PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED,
+		PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
 		PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE,
-		1,
-		1024,
+		4,
+		1024, // Estimated public key size is 2048 bits, assuming perfect packing (not the case) this can hold 4 public keys at once (a public key being the largest object to be used in a registration handshake)
 		1024,
 		50,
 		NULL
 	);
 
 	std::cout << GetLastError() << std::endl;
+
+	/*
+	Need to use win32 threads as my gcc doesn't like posix, I think because I told it to on installation. I could just reinstall, but where's the fun in that?
+	Besides, we're already going to be writting platform-specific code, using the native functions gives us more control, and should in theory give a tiny performance edge, not that we need it for anything.
+	*/
+	// Should do this after core server has finished starting up
+	// Is 1024 bytes enough for C++ std i/o?
+	CreateThread(
+		NULL,
+		1024,
+		inputThread,
+		NULL,
+		0,
+		NULL
+	);
+
+	OVERLAPPED state = {};
+
+	ConnectNamedPipe(pipe, &state);
+
+	DWORD bytes = 0;
+	char buffer[2] = {};
+	OVERLAPPED overlapped = {};
+
+	while (true) {
+		// Readfile may "fail" occasionally at high check rates as it is asynchronous"
+		if (bytes != 0) {
+			std::cout << "Connected: " << +buffer[0] << "/" << +buffer[1] << std::endl;
+
+			DisconnectNamedPipe(pipe);
+
+			break;
+		}
+
+		ReadFile(
+			pipe,
+			&buffer,
+			2,
+			&bytes,
+			&overlapped
+		);
+
+		if (shouldExit) {
+			break;
+		}
+
+		Sleep(500);
+	}
 
 	CloseHandle(pipe);
 

--- a/core/Global.h
+++ b/core/Global.h
@@ -1,1 +1,1 @@
-#define VERSION "0.1.0-alpha.2" // Different than project version for now
+#define VERSION "0.1.0-alpha.3" // Different than project version until subsystems are moved

--- a/core/Global.h
+++ b/core/Global.h
@@ -1,1 +1,3 @@
+#pragma once
+
 #define VERSION "0.1.0-alpha.3" // Different than project version until subsystems are moved

--- a/core/registration/PipeServer.cpp
+++ b/core/registration/PipeServer.cpp
@@ -1,0 +1,140 @@
+#include "PipeServer.h"
+
+#include "Register.h"
+
+#include <Windows.h>
+#include <iostream>
+
+// TODO: replace with variable; pipe count must be <= maxSubsystems
+#define PIPE_COUNT 2
+#define PIPE_BUFFER_SIZE 32
+
+struct PipeInst {
+	HANDLE handle = INVALID_HANDLE_VALUE;
+
+	bool waiting = false;
+
+	DWORD bytesRead;
+	char buffer[PIPE_BUFFER_SIZE]; 
+
+	OVERLAPPED overlap;
+};
+ 
+PipeInst pipes[PIPE_COUNT];
+
+bool registration_server::init() {
+    for (int i = 0; i < PIPE_COUNT; i++) {
+		/*
+		! Inherently, this opens up the core server to malicious use,
+		! extreme care must be taken to insure no information is shared that could compromise the host machine.
+
+		This should be shared with subsystem developers in an obvious place, along with a message encouraging them to write secure network code.
+		Even still, the subsystem api should be written in such a way to reduce the risk of an experienced dev opening up their system for exploitation.
+
+		Because of this, a subsystem-side api should be provided, and developers should be highly encouraged to use it, doing otherwise at their own (and any of their users) risk.
+
+		Some/all network data should be encrypted, or an option should at least exist for it (maybe subsystems could opt-in to full or partial encryption depending on their content),
+		as some users may prefer the slight performance boost in exchange for third parties being able to see the volume of dirt transferred between two games (of course network data may not always be so insignificant)
+		*/
+		pipes[i].handle = CreateNamedPipeA(
+			"\\\\.\\pipe\\FMBCRegister",
+			PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+			PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE,
+			4,
+			1024, // Estimated public key size is 2048 bits, assuming perfect packing (not the case) this can hold 4 public keys at once (a public key being the largest object to be used in a registration handshake)
+			1024,
+			50,
+			NULL
+		);
+
+		if (pipes[i].handle == INVALID_HANDLE_VALUE) {
+			std::cout << "Failed to initialize pipe#" << i << " with error " << GetLastError()
+				<< ". This could be because a previous session was not cleaned up completely, or an application could be attempting to hijack communication." << std::endl;
+
+			return false;
+		}
+
+		// ? Should this be a separate function?
+		ConnectNamedPipe(pipes[i].handle, &pipes[i].overlap);
+
+		DWORD error = GetLastError();
+
+		if (error != ERROR_IO_PENDING && error != ERROR_PIPE_CONNECTED) {
+			std::cout << "Pipe#" << i << " failed to enable incoming connections with error " << GetLastError() << std::endl;
+
+			return false;
+		} else {
+			std::cout << "Pipe#" << i << " waiting for incoming connections" << std::endl;
+		}
+	}
+
+    return true;
+}
+
+bool registration_server::cycle() {
+	// TODO: this whole system needs improvement
+	for (int i = 0; i < PIPE_COUNT; i++) {
+		if (pipes[i].waiting) {	
+			if (HasOverlappedIoCompleted(&pipes[i].overlap)) {
+				std::cout << "Pipe#" << i << " finished job, disconnecting subsystem and waiting for a new connection" << std::endl;
+
+				pipes[i].waiting = false;
+
+				DisconnectNamedPipe(pipes[i].handle);
+				// TODO: move reconnect code to a function
+				ConnectNamedPipe(pipes[i].handle, &pipes[i].overlap);
+
+				DWORD error = GetLastError();
+
+				if (error != ERROR_IO_PENDING && error != ERROR_PIPE_CONNECTED) {
+					std::cout << "Pipe#" << i << " failed to re-enable incoming connections with error " << GetLastError() << std::endl;
+
+					// ? Should not exit right away maybe
+					return false;
+				}
+			}
+		} else {
+			ReadFile(
+				pipes[i].handle,
+				&pipes[i].buffer,
+				PIPE_BUFFER_SIZE,
+				&pipes[i].bytesRead,
+				&pipes[i].overlap
+			);
+
+			if (pipes[i].bytesRead != 0) {
+				std::cout << "Connection received on pipe#" << i << std::endl;
+
+				SessionId* id = client_register::addClient(pipes[i].buffer + 6, *(unsigned char*) (pipes[i].buffer + 5), *(uint32_t*) (pipes[i].buffer + 1));
+
+				if (id == nullptr) {
+					// TODO: implement actual code for this; pipes should notify subsystems attempting to connect that their connection cannot be serviced to prevent them from assuming an instance will soon be available to answer their request.
+					std::cout << "Warning, maximum number of subsystems reached" << std::endl;
+
+					return false;
+				}
+
+				WriteFile(
+					pipes[i].handle,
+					id,
+					16,
+					NULL,
+					&pipes[i].overlap
+				);
+
+				pipes[i].bytesRead = 0;
+				pipes[i].waiting = true;
+			}
+		}
+	}
+
+	return true;
+}
+
+void registration_server::cleanup() {
+	for (int i = 0; i < PIPE_COUNT; i++) {
+		if (pipes[i].handle != INVALID_HANDLE_VALUE) {
+			CloseHandle(pipes[i].handle);
+		}
+	}
+}

--- a/core/registration/PipeServer.h
+++ b/core/registration/PipeServer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// TODO: this namespace should be more modularized
 namespace registration_server {
 
     bool init();

--- a/core/registration/PipeServer.h
+++ b/core/registration/PipeServer.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace registration_server {
+
+    bool init();
+
+    bool cycle();
+
+    // ? Can this be done better?
+    void cleanup();
+
+}

--- a/core/registration/Register.cpp
+++ b/core/registration/Register.cpp
@@ -1,0 +1,60 @@
+#include "Register.h"
+
+#include <windows.h>
+#include <iostream>
+#include <vector>
+
+// ? Put in header? ----------------------------------------
+#include <cstdint>
+
+// This ordering should be fairly optimal for memory/performance
+struct Client {
+	HANDLE communication;
+	SessionId sessionId;
+
+	char name[24];
+};
+// ? -------------------------------------------------------
+
+unsigned char maxClients = 2; // Could probably just use an int, but this adds another level of protection from runoff
+// ? Maybe replace with preallocated array, custom allocator, or some other data structure?
+std::vector<Client> clients;
+
+void client_register::init(unsigned char maxClients) {
+	::maxClients = maxClients;
+}
+
+// TODO: max nameLength must be 24 - 1 (- 1 so a null terminator can be inserted)
+SessionId* client_register::addClient(char* name, unsigned char nameLength, uint32_t processId) {
+	if (clients.size() == maxClients) {
+		return nullptr;
+	}
+
+	clients.push_back({NULL, {0, 0xa538f}, {}}); // TODO: generate a unique SID automatically
+
+	// TODO: Reduce number of instances of clients[clients.size() - 1]
+	memcpy(&clients[clients.size() - 1].name, name, nameLength);
+	clients[clients.size() - 1].name[nameLength] = 0; // Adds a null terminator
+
+	std::cout << "Name (Length " << +nameLength << "): " << clients[clients.size() - 1].name << std::endl;
+	std::cout << "PID: " << processId << std::endl;
+
+	return &clients[clients.size() - 1].sessionId;
+}
+
+bool client_register::removeClient(unsigned char index) {
+	if (index < clients.size()) {
+		// TODO: This can probably be done better
+		// ? Does erase() return -1/0/etc one failure?
+		clients.erase(clients.begin() + index);
+
+		return true;
+	}
+
+	// ? Does skipping the else give worse/better/same performance?
+	return false;
+}
+
+unsigned char client_register::size() {
+	return clients.size();
+}

--- a/core/registration/Register.h
+++ b/core/registration/Register.h
@@ -4,8 +4,6 @@
 
 typedef uint64_t SessionId[2]; // 64 bits * 2 = 128 bits
 
-//typedef void* HANDLE;
-
 /*
 Contains the functions necessary to interact with the internal list of registered clients.
 */
@@ -25,6 +23,7 @@ namespace client_register {
 
     Returns a pointer to a unique session id to be given to the requesting client, or nullptr if adding the client would bring the number of registered clients over the internal maximum.
     */
+    // TODO: start replacing win32 types with either generic types or a preprocessor selected type in preperation for the mac/linux port
     SessionId* addClient(char* name, unsigned char nameLength, uint32_t processId);
 
     /*
@@ -39,6 +38,6 @@ namespace client_register {
     */
     unsigned char size();
 
-    // TODO: add [] override
+    // TODO: add [] override maybe
 
 }

--- a/core/registration/Register.h
+++ b/core/registration/Register.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+
+typedef uint64_t SessionId[2]; // 64 bits * 2 = 128 bits
+
+//typedef void* HANDLE;
+
+/*
+Contains the functions necessary to interact with the internal list of registered clients.
+*/
+namespace client_register {
+
+    /*
+    Initializes the client register with a given maximum number of registered clients.
+
+    This method should only be called once.
+    */
+    void init(unsigned char maxClients);
+
+    /*
+    Adds a client to the internal register.
+
+    The returned pointer should not be written to, only read from.
+
+    Returns a pointer to a unique session id to be given to the requesting client, or nullptr if adding the client would bring the number of registered clients over the internal maximum.
+    */
+    SessionId* addClient(char* name, unsigned char nameLength, uint32_t processId);
+
+    /*
+    Removes the client at the given index.
+
+    Returns false if no client is registered at the provided index.
+    */
+    bool removeClient(unsigned char index);
+
+    /*
+    Returns the number of registered clients.
+    */
+    unsigned char size();
+
+    // TODO: add [] override
+
+}

--- a/info.json
+++ b/info.json
@@ -1,3 +1,3 @@
 {
-  "version":"0.1.0-alpha.5"
+  "version":"0.2.1-alpha"
 }

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(memory)

--- a/shared/memory/BufferAccess.h
+++ b/shared/memory/BufferAccess.h
@@ -5,9 +5,9 @@
 #include <cstdint>
 
 /*
-Contains methods needed to interact with the shared IPC buffer.
+Contains functions needed to interact with the shared IPC buffer.
 
-Subsystems should use these methods instead of creating their own implementations to keep the process consistent.
+Subsystems should use these functions instead of creating their own implementations to keep the process consistent.
 */
 namespace ipc {
 
@@ -42,8 +42,8 @@ namespace ipc {
 	Unmaps the IPC buffer from the calling process's memory space and closes the associated handle.
 	
 	This function will attempt to close the associated handle regardless of whether or not it was able to unmap the buffer, though the return value will reflect the failure.
-	Failure to fully complete may result in the buffer staying in system memory untill a restart, so processes should strive to insure this function can fully complete,
-	or cleanup manually if that is not possibble for whatever reason.
+	Failure to fully complete may result in the buffer staying in system memory until a restart, so processes should strive to insure this function can fully complete,
+	or cleanup manually if that is not possible for whatever reason.
 	
 	Returns
 		0: If the function completed successfully.

--- a/shared/memory/Global.h
+++ b/shared/memory/Global.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// ? Can this be done better?
 namespace {
 
 #include <WinDef.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(subsystem)

--- a/tests/subsystem/CMakeLists.txt
+++ b/tests/subsystem/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_executable(Test_Subsystem Run.cpp)

--- a/tests/subsystem/Run.cpp
+++ b/tests/subsystem/Run.cpp
@@ -22,7 +22,9 @@ int main() {
         NMPWAIT_NOWAIT
     );
 
-    std::cout << "Data received: ";
+    std::cout << "Data received" << std::endl;
+
+    std::cout << "Session Id: ";
     for (int i = 0; i < bytesRead; i++){
         std::cout << +in[i] << " ";
     }

--- a/tests/subsystem/Run.cpp
+++ b/tests/subsystem/Run.cpp
@@ -5,21 +5,24 @@
 int main() {
     std::cout << "Attempting to connect to core server" << std::endl;
 
-    DWORD bytes;
+    DWORD bytesRead;
 
-    char data[2] = {1, 2};
+    // Type: REGISTER_NEW (1), PID: 2305 (1 9 0 0), Name: Test\0 (84 101 115 116 0)
+    unsigned char out[10] = {1, 1, 9, 0, 0, 84, 101, 115, 116, 0};
+    char in[32];
 
     CallNamedPipeA(
         "\\\\.\\pipe\\FMBCRegister",
-        &data,
-        2,
-        NULL,
-        0,
-        &bytes,
+        &out,
+        10,
+        &in,
+        32,
+        &bytesRead,
         NMPWAIT_NOWAIT
     );
 
-    std::cout << GetLastError() << std::endl;
+    std::cout << "Data received: " << in << std::endl;
+    std::cout << bytesRead << " bytes read" << std::endl;
 
     return 0;
 }

--- a/tests/subsystem/Run.cpp
+++ b/tests/subsystem/Run.cpp
@@ -1,15 +1,16 @@
 #include <iostream>
 
 #include <Windows.h>
+#include <cstdint>
 
 int main() {
     std::cout << "Attempting to connect to core server" << std::endl;
 
     DWORD bytesRead;
 
-    // Type: REGISTER_NEW (1), PID: 2305 (1 9 0 0), Name: Test\0 (84 101 115 116 0)
-    unsigned char out[10] = {1, 1, 9, 0, 0, 84, 101, 115, 116, 0};
-    char in[32];
+    // Type: REGISTER_NEW (1), PID: 2305 (1 9 0 0), Name Size: 4 (4), Name: Test (84 101 115 116)
+    unsigned char out[10] = {1, 1, 9, 0, 0, 4, 84, 101, 115, 116};
+    unsigned char in[32];
 
     CallNamedPipeA(
         "\\\\.\\pipe\\FMBCRegister",
@@ -21,7 +22,12 @@ int main() {
         NMPWAIT_NOWAIT
     );
 
-    std::cout << "Data received: " << in << std::endl;
+    std::cout << "Data received: ";
+    for (int i = 0; i < bytesRead; i++){
+        std::cout << +in[i] << " ";
+    }
+    std::cout << std::endl;
+
     std::cout << bytesRead << " bytes read" << std::endl;
 
     return 0;

--- a/tests/subsystem/Run.cpp
+++ b/tests/subsystem/Run.cpp
@@ -5,12 +5,21 @@
 int main() {
     std::cout << "Attempting to connect to core server" << std::endl;
 
+    DWORD bytes;
+
+    char data[2] = {1, 2};
+
     CallNamedPipeA(
-        "FMCBCoreConnect",
-         
-
-
+        "\\\\.\\pipe\\FMBCRegister",
+        &data,
+        2,
+        NULL,
+        0,
+        &bytes,
+        NMPWAIT_NOWAIT
     );
+
+    std::cout << GetLastError() << std::endl;
 
     return 0;
 }

--- a/tests/subsystem/Run.cpp
+++ b/tests/subsystem/Run.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+
+#include <Windows.h>
+
+int main() {
+    std::cout << "Attempting to connect to core server" << std::endl;
+
+    CallNamedPipeA(
+        "FMCBCoreConnect",
+         
+
+
+    );
+
+    return 0;
+}


### PR DESCRIPTION
Implements the first stage of development for the core server: the registration code, which allows a (local only for now) subsystem to connect to a named win32 pipe, provide some information about themselves, and (potentially) receive a unique communication channel (actually generating a handle should be implemented later), and any data that goes along with it (session id, etc). Docs can be found on the project wiki.