### PR TITLE
Replace C-style casts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo" CACHE STRING "")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # -mno-ms-bitfields is only needed to make -Wpadded work correctly, this could cause problems down the line. A gnu bugzilla report has been filed under the id: 100058
-set(CMAKE_CXX_FLAGS "-std=c++17 -mno-ms-bitfields -fdiagnostics-color=always")
+set(CMAKE_CXX_FLAGS "-std=c++17 -mno-ms-bitfields -fdiagnostics-color=always -fno-rtti")
 
 set(CXX_WARNINGS "-Wall -Wextra -Wold-style-cast -Wshadow -Wdouble-promotion -Wundef -Wconversion -Wcast-align=strict -Wpadded")
 

--- a/core/registration/PipeServer.cpp
+++ b/core/registration/PipeServer.cpp
@@ -135,7 +135,7 @@ bool registration_server::cycle() {
 					HANDLE clientHandle = OpenProcess(
 						PROCESS_DUP_HANDLE,
 						false,
-						*(uint32_t*) (pipes[i].buffer + 1)
+						*reinterpret_cast<uint32_t*>(pipes[i].buffer + 1)
 					);
 
 					// ? What happens if the client doesn't close this handle? Should we close it?
@@ -143,7 +143,7 @@ bool registration_server::cycle() {
 						GetCurrentProcess(),
 						client -> fileHandle,
 						clientHandle,
-						(HANDLE*) (message + 17),
+						reinterpret_cast<HANDLE*>(message + 17),
 						NULL,
 						false,
 						DUPLICATE_SAME_ACCESS 

--- a/shared/register/Register.cpp
+++ b/shared/register/Register.cpp
@@ -29,7 +29,7 @@ char registration::request() {
     unsigned char in[32];
 
     // TODO: cleanup
-    *(DWORD*) (out + 1) = GetCurrentProcessId();
+    *reinterpret_cast<DWORD*>(out + 1) = GetCurrentProcessId();
 
     // TODO: can we find a use for this?
     DWORD bytesRead;
@@ -55,7 +55,7 @@ char registration::request() {
     // TODO: cleanup
     if (in[0] == 0) { // if successful
         api_global::bufferSize = 1024;
-        api_global::fileHandle = *(HANDLE*) (in + 17);
+        api_global::fileHandle = *reinterpret_cast<DWORD**>(in + 17);
     }
 
     return in[0];

--- a/tests/subsystem/Run.cpp
+++ b/tests/subsystem/Run.cpp
@@ -43,9 +43,9 @@ int main() {
     if (registration::request() == 0) {
         std::cout << "Connection successful" << std::endl;
 
-        char* comm = (char*) communication::map();
+        char* comm = reinterpret_cast<char*>(communication::map());
 
-        std::cout << (void*) comm << std::endl;
+        std::cout << reinterpret_cast<void*>(comm) << std::endl;
 
         comm[0] = 5;
 


### PR DESCRIPTION
With the help of -Wold-style-cast, replaces all instances of C-style casts with C++ casts. For the vast majority of cases, replacement is reinterpret_cast for efficiency.